### PR TITLE
remove setuptools from requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "actinia-metadata-plugin"
-version = "1.0.4"
+version = "1.0.5"
 description = "A (RESTFUL) Flask application which to communicate with a metadata catalog via OGC-CSW, in usage with GeoNetwork opensource."
 readme = "README.md"
 authors = [
@@ -41,7 +41,6 @@ dependencies = [
     "pytest-cov>=2.5.1",
     "python-json-logger",
     "requests>=2.20.0",
-    "setuptools>=30.3.0",
     "xmltodict>=0.11",
 ]
 


### PR DESCRIPTION
setuptools is (at least should not be) not a runtime dependency, however with a specific version pinned in the actinia-grassdata-management-plugin, it causes a version conflict with actinia-core==7.1.1
Therefore I suggest to remove it from dependencies (also from other plugins like here).