### PR TITLE
Enhance config message

### DIFF
--- a/src/actinia_metadata_plugin/resources/config.py
+++ b/src/actinia_metadata_plugin/resources/config.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-SPDX-FileCopyrightText: (c) 2018-2021 mundialis GmbH & Co. KG
+SPDX-FileCopyrightText: (c) 2018-2021 mundialis GmbH & Co. KG.
 
-SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: Apache-2.0.
 
-Configuration file
+Configuration file.
 """
 
 __author__ = "Carmen Tawalika"
@@ -14,62 +14,67 @@ __license__ = "Apache-2.0"
 
 
 import configparser
-import glob
 from pathlib import Path
 
 # config can be overwritten by mounting *.ini files into folders inside
 # the config folder.
 DEFAULT_CONFIG_PATH = "config"
-CONFIG_FILES = [str(f) for f in Path(
-    DEFAULT_CONFIG_PATH).glob('**/*.ini') if f.is_file()]
-GENERATED_CONFIG = DEFAULT_CONFIG_PATH + '/actinia-metadata-plugin.cfg'
+CONFIG_FILES = [
+    str(f) for f in Path(DEFAULT_CONFIG_PATH).glob("**/*.ini") if f.is_file()
+]
+GENERATED_CONFIG = DEFAULT_CONFIG_PATH + "/actinia-metadata-plugin.cfg"
 
 
 class GEONETWORK:
-    """Default config for connection to geonetwork
-    """
-    scheme = 'http'
-    host = 'localhost'
-    port = '1234'
-    base_path = '/geonetwork'
-    csw_path = '/srv/eng/csw'
-    csw_publication = '/srv/eng/csw-publication'
-    user = 'test'
-    password = 'test'
-    csw_url = scheme + '://' + host + ':' + port + base_path + csw_path
+    """Default config for connection to geonetwork."""
+
+    scheme = "http"
+    host = "localhost"
+    port = "1234"
+    base_path = "/geonetwork"
+    csw_path = "/srv/eng/csw"
+    csw_publication = "/srv/eng/csw-publication"
+    user = "test"
+    password = "test"
+    csw_url = scheme + "://" + host + ":" + port + base_path + csw_path
 
 
 class LOGCONFIG:
-    """Default config for logging
-    """
-    logfile = 'actinia-metadata-plugin.log'
-    level = 'DEBUG'
-    type = 'stdout'
+    """Default config for logging."""
+
+    logfile = "actinia-metadata-plugin.log"
+    level = "DEBUG"
+    type = "stdout"
 
 
 class FILEUPLOAD:
-    geodata = '/tmp/'
-    templates = '/tmp/'
+    """Default config for file upload."""
+
+    geodata = "/tmp/"
+    templates = "/tmp/"
 
 
 class Configfile:
+    """Reads config files and overwrites the default config classes above."""
 
-    def __init__(self):
-        """
-        This class will overwrite the config classes above when config files
-        named DEFAULT_CONFIG_PATH/**/*.ini exist.
+    def __init__(self) -> None:
+        """Overwrites the config classes above
+        when config files named DEFAULT_CONFIG_PATH/**/*.ini exist.
+
         On first import of the module it is initialized.
         """
-
         config = configparser.ConfigParser()
         config.read(CONFIG_FILES)
 
         if len(config) <= 1:
-            print("No actinia-metadata-plugin config found. Using default plugin settings.")
+            print(
+                "No actinia-metadata-plugin config found. "
+                "Using default plugin settings.",
+            )
             return
         print("Loading config files: " + str(CONFIG_FILES) + " ...")
 
-        with open(GENERATED_CONFIG, 'w') as configfile:
+        with Path(GENERATED_CONFIG).open("w") as configfile:
             config.write(configfile)
         print("Configuration written to " + GENERATED_CONFIG)
 
@@ -87,35 +92,48 @@ class Configfile:
                 GEONETWORK.csw_path = config.get("GEONETWORK", "csw_path")
             if config.has_option("GEONETWORK", "csw_create_path"):
                 GEONETWORK.csw_create_path = config.get(
-                    "GEONETWORK", "csw_create_path")
+                    "GEONETWORK", "csw_create_path",
+                )
             if config.has_option("GEONETWORK", "user"):
                 GEONETWORK.user = config.get("GEONETWORK", "user")
             if config.has_option("GEONETWORK", "password"):
                 GEONETWORK.password = config.get("GEONETWORK", "password")
 
-            if (config.has_option("GEONETWORK", "scheme") and
-                    config.has_option("GEONETWORK", "host") and
-                    config.has_option("GEONETWORK", "port") and
-                    config.has_option("GEONETWORK", "base_path") and
-                    config.has_option("GEONETWORK", "csw_path")):
+            if (
+                config.has_option("GEONETWORK", "scheme")
+                and config.has_option("GEONETWORK", "host")
+                and config.has_option("GEONETWORK", "port")
+                and config.has_option("GEONETWORK", "base_path")
+                and config.has_option("GEONETWORK", "csw_path")
+            ):
 
-                GEONETWORK.csw_url = (GEONETWORK.scheme + '://' +
-                                      GEONETWORK.host + ':' +
-                                      GEONETWORK.port +
-                                      GEONETWORK.base_path +
-                                      GEONETWORK.csw_path)
+                GEONETWORK.csw_url = (
+                    GEONETWORK.scheme
+                    + "://"
+                    + GEONETWORK.host
+                    + ":"
+                    + GEONETWORK.port
+                    + GEONETWORK.base_path
+                    + GEONETWORK.csw_path
+                )
 
-            if (config.has_option("GEONETWORK", "scheme") and
-                    config.has_option("GEONETWORK", "host") and
-                    config.has_option("GEONETWORK", "port") and
-                    config.has_option("GEONETWORK", "base_path") and
-                    config.has_option("GEONETWORK", "csw_publication")):
+            if (
+                config.has_option("GEONETWORK", "scheme")
+                and config.has_option("GEONETWORK", "host")
+                and config.has_option("GEONETWORK", "port")
+                and config.has_option("GEONETWORK", "base_path")
+                and config.has_option("GEONETWORK", "csw_publication")
+            ):
 
-                GEONETWORK.csw_publication = (GEONETWORK.scheme + '://' +
-                                              GEONETWORK.host + ':' +
-                                              GEONETWORK.port +
-                                              GEONETWORK.base_path +
-                                              GEONETWORK.csw_publication)
+                GEONETWORK.csw_publication = (
+                    GEONETWORK.scheme
+                    + "://"
+                    + GEONETWORK.host
+                    + ":"
+                    + GEONETWORK.port
+                    + GEONETWORK.base_path
+                    + GEONETWORK.csw_publication
+                )
 
         # LOGGING
         if config.has_section("LOGCONFIG"):

--- a/src/actinia_metadata_plugin/resources/config.py
+++ b/src/actinia_metadata_plugin/resources/config.py
@@ -65,7 +65,7 @@ class Configfile:
         config.read(CONFIG_FILES)
 
         if len(config) <= 1:
-            print("Could not find any config file, using default values.")
+            print("No actinia-metadata-plugin config found. Using default plugin settings.")
             return
         print("Loading config files: " + str(CONFIG_FILES) + " ...")
 


### PR DESCRIPTION
This PR clarifies the startup message shown when no configuration file is found for the `actinia-metadata-plugin`.
The new message explicitly states that the missing configuration belongs to the plugin and that default plugin settings are used.
Fixes actinia-org/actinia-module-plugin#34